### PR TITLE
Customize session with SessionOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ NTS-capable NTP server. Once the session has been created, the network
 connection to the key-exchange server is immediately dropped and all future
 queries proceed via NTP using the session's query functions.
 
+If you wish to customize the behavior of the session, you may do so by using
+[`NewSessionWithOptions`](https://godoc.org/github.com/beevik/nts#NewSessionWithOptions)
+instead of `NewSession`.
+
+```go
+opt := &nts.SessionOptions{
+    TLSConfig: &tls.Config{
+        RootCAs: certPool,
+    },
+}
+session, err := nts.NewSessionWithOptions(host, opt)
+```
+
+See the documentation for
+[`SessionOptions`](https://godoc.org/github.com/beevik/nts#SessionOptions) for a
+list of available customizations.
 
 ## Querying time synchronization data
 

--- a/ntske.go
+++ b/ntske.go
@@ -45,11 +45,13 @@ const (
 )
 
 func (s *Session) performKeyExchange() error {
-	tlsConfig := &tls.Config{
-		InsecureSkipVerify: false,
-		MinVersion:         tls.VersionTLS13,
-		NextProtos:         []string{ntskeProtocol},
+	tlsConfig := s.tlsConfig
+	if s.tlsConfig == nil {
+		tlsConfig = &tls.Config{}
 	}
+	tlsConfig.MinVersion = tls.VersionTLS13
+	tlsConfig.NextProtos = []string{ntskeProtocol}
+
 	dialer := &net.Dialer{Timeout: time.Second * 5}
 	conn, err := tls.DialWithDialer(dialer, "tcp", s.ntskeAddr, tlsConfig)
 	if err != nil {


### PR DESCRIPTION
Added `NewSessionWithOptions` to allow customization of session.
The `SessionOptions` contains a TLSConfig parameter to allow use cases such as allowing specific Root CA certificates.