### PR TITLE
Add more NTS SessionOptions

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,1 @@
+Chris Lamb (lambchr)

--- a/README.md
+++ b/README.md
@@ -32,13 +32,16 @@ queries proceed via NTP using the session's query functions.
 
 If you wish to customize the behavior of the session, you may do so by using
 [`NewSessionWithOptions`](https://godoc.org/github.com/beevik/nts#NewSessionWithOptions)
-instead of `NewSession`.
+instead of `NewSession`. For example:
 
 ```go
 opt := &nts.SessionOptions{
     TLSConfig: &tls.Config{
         RootCAs: certPool,
     },
+    Timeout: 30 * time.Second,
+    Dialer: customDialer,
+    Resolver: customResolver,
 }
 session, err := nts.NewSessionWithOptions(host, opt)
 ```


### PR DESCRIPTION
Added Timeout to override the default TLS connection timeout of 5 seconds.

Added Dialer to override the default TLS connection dialer function.

Added Resolver to override the NTP server address returned by the key exchange protocol.