### PR TITLE
Fix error handling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ synchronization data.
 ```go
 response, err := session.Query();
 
-if err == nil { // no error
+if err != nil {
+   // handle error
+}
+
+if response != nil { // no error
     accurateTime := time.Now().Add(response.ClockOffset)
     fmt.Printf("The current time is: %s\n", accurateTime)
 }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ After successful establishment of the session, you may issue NTP
 synchronization data.
 
 ```go
-if response, err := session.Query(); err != nil {
+response, err := session.Query();
+
+if err == nil { // no error
     accurateTime := time.Now().Add(response.ClockOffset)
     fmt.Printf("The current time is: %s\n", accurateTime)
 }


### PR DESCRIPTION
response can only be used when `err` is `nil`.
If `err != nil` as written in the README that means an error has occured.

Using the code as written in the README results in a crash, because when `err != nil`, very likely `response` will be `nil`!
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x5cb34c]

goroutine 1 [running]:
main.main()
        /home/edwint/git/nethsm/nethsm/nts/main.go:20 +0x10c
```

(This can be reproduced by inserting a 10s sleep between creating a session and attempting to query it, and then disconnecting the machine from the network to trigger an error)